### PR TITLE
Allow env to pass options in main program shebang line

### DIFF
--- a/bin/raku-logs-server
+++ b/bin/raku-logs-server
@@ -1,4 +1,4 @@
-#!/usr/bin/env raku --ll-exception
+#!/usr/bin/env -S raku --ll-exception
 BEGIN %*ENV<RAKUDO_PRECOMPILATION_PROGRESS> = 1;
 
 use App::Raku::Log:ver<0.0.35>:auth<zef:lizmat>;


### PR DESCRIPTION
When running the main program on Linux, `env` (which is used in the main program's shebang line) throws this error:

```shell
$ ./bin/raku-logs-server
/usr/bin/env: ‘raku --ll-exception’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

In order to fix this issue, one needs to pass the [`-S` option to `env`](https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html#g_t_002dS_002f_002d_002dsplit_002dstring-usage-in-scripts) so that `env` can split the string passed to it and thus pass the arguments to the interpreting program (i.e. `raku`).

Here's another dive-by-PR...

I would have thought that you'd have spotted this before (it surprised me that I ran into it and didn't know that such things could be an issue), so maybe the behaviour of `env` on MacOS is different.  Unfortunately, I don't have a Mac to test this change on, so I can only provide a change which makes `raku-logs-server` run on my system. :-/  As with all of my PRs, they're merely proposals and I'm completely ok if you don't want to merge it or anything.  Also, if anything needs changing I'm more than happy to update the code as appropriate and resubmit.